### PR TITLE
Publish to PyPi via actions, update readme

### DIFF
--- a/.github/scripts/update_version.py
+++ b/.github/scripts/update_version.py
@@ -1,0 +1,35 @@
+"""
+This CLI script is used to update the version of the package. It is used by the
+CI/CD pipeline to update the version of the package when a new release is made.
+
+It uses argparse to parse the command line arguments, which are the new version
+and the path to the package's __init__.py file.
+"""
+
+import argparse
+from pathlib import Path
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Update the version of the package."
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        help="The new version of the package.",
+        required=True,
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        help="The path to the package's version file.",
+        default="instruct_qa/version.py",
+    )
+    args = parser.parse_args()
+
+    with open(args.path, "w") as f:
+        f.write(f"__version__ = \"{args.version}\"")
+        
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -30,9 +30,6 @@ jobs:
         python .github/scripts/update_version.py --version $RELEASE_TAG
     
     - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   publish-on-pypi:
-    needs: update-version  # IMPORTANT: ensures that version is updated before publishing
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release
     permissions:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -8,13 +8,8 @@ on:
     types: [created]
 
 jobs:
-  publish-on-pypi:
+  update-version:
     runs-on: ubuntu-latest
-    # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: release
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -28,5 +23,14 @@ jobs:
       run: |
         python .github/scripts/update_version.py --version $RELEASE_TAG
 
+  publish-on-pypi:
+    runs-on: ubuntu-latest
+    needs: update-version  # IMPORTANT: ensures that version is updated before publishing
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:  
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -8,8 +8,7 @@ on:
     types: [created]
 
 jobs:
-  deploy:
-
+  publish-on-pypi:
     runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release
@@ -22,21 +21,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    
+
     - name: Update version.py with release tag
       env:
         RELEASE_TAG: ${{ github.event.release.tag_name }}
       run: |
         python .github/scripts/update_version.py --version $RELEASE_TAG
-    
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,38 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    
+    - name: Update version.py with release tag
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+      run: |
+        python .github/scripts/update_version.py --version $RELEASE_TAG
+    
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -11,7 +11,11 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
-
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -30,6 +34,9 @@ jobs:
         python .github/scripts/update_version.py --version $RELEASE_TAG
     
     - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -8,7 +8,14 @@ on:
     types: [created]
 
 jobs:
-  update-version:
+  publish-on-pypi:
+    needs: update-version  # IMPORTANT: ensures that version is updated before publishing
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -23,14 +30,14 @@ jobs:
       run: |
         python .github/scripts/update_version.py --version $RELEASE_TAG
 
-  publish-on-pypi:
-    runs-on: ubuntu-latest
-    needs: update-version  # IMPORTANT: ensures that version is updated before publishing
-    # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: release
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-    steps:  
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools twine wheel
+    
+    - name: Build package by running setup.py
+      run: |
+        python setup.py sdist bdist_wheel
+    
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -2,15 +2,39 @@
 
 [![arXiv](https://img.shields.io/badge/arXiv-2307.16877-b31b1b.svg)](https://arxiv.org/abs/2307.16877)
 [![License](https://img.shields.io/badge/License-Apache_2.0-yellowgreen.svg)](https://opensource.org/licenses/Apache-2.0)  
-
+[![PyPi](https://img.shields.io/pypi/v/instruct-qa)](https://pypi.org/project/instruct-qa/)
 
 ## Quick Start
 ### Installation
-You can install the library via pip.
 
+Make sure you have Python 3.7+ installed. It is also a good idea to use a virtual environment.
+<details>
+<summary>Show instructions for Virtual Environments</summary>
+<br>
+```bash
+python3 -m venv instruct-qa-venv
+source instruct-qa-venv/bin/activate
 ```
-pip install -e .
+</details>
+
+
+You can install the library via `pip`:
+
+```bash
+# Install the latest release
+pip3 install instruct-qa
+
+# Install the latest version from GitHub
+pip3 install git+https://github.com/McGill-NLP/instruct-qa
 ```
+
+For development, you can install it in editable mode with:
+```
+git clone https://github.com/McGill-NLP/instruct-qa
+cd instruct-qa/
+pip3 install -e .
+```
+
 ### Usage
 Here is a simple example to get started. Using this library, use can easily leverage retrieval-augmented instruction-following models for question-answering in ~25 lines of code. The source file for this example is [examples/get_started.py](examples/get_started.py).
 ```python

--- a/instruct_qa/version.py
+++ b/instruct_qa/version.py
@@ -1,0 +1,5 @@
+__version__ = "0.0.1"
+
+# NOTE: Do not modify this manually. Version is automatically updated in
+# .github/scripts/update_version.py when .github/workflows/publish-python.yml 
+# is run.

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,21 @@
-from setuptools import setup
+from setuptools import setup, find_packages
+
+
+version = {}
+with open("instruct_qa/version.py") as fp:
+    exec(fp.read(), version)
+
+with open("README.md") as fp:
+    long_description = fp.read()
 
 setup(
     name="instruct-qa",
     description="Empirical evaluation of retrieval-augmented instruction-following models.",
-    version="0.0.1",
+    version=version["__version__"],
+    author="McGill NLP",
     url="https://github.com/McGill-NLP/instruct-qa",
     python_requires=">=3.7",
-    packages=["instruct_qa"],
+    packages=find_packages(include=['instruct_qa*']),
     install_requires=[
         "torch",
         "transformers",
@@ -29,6 +38,14 @@ setup(
     extras_require={
         "evaluation": ["tensorflow-text", "bert_score", "allennlp", "allennlp-models"],
     },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+        # Apache license
+        "License :: OSI Approved :: Apache Software License",
+    ],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
It is now very easy to publish to PyPi. All you need to do is to:

1. Create a new GitHub release ([click here to create a new one](https://github.com/McGill-NLP/instruct-qa/releases/new)). 
2. Select a new tag (usually, you bump the `patch` in `major.minor.patch`, e.g. `v0.0.1` -> `v0.0.2`).
    * `Target` should remain on `main`. You only need to change it if you want to make a pre-release based on a different branch, but that should be very rare.
4. Keep the release title blank
5. Write a list of changes (use section titles like `Fix`, `Updated`, `Removed` and `New`

When you press `Publish release`, a new action will appear in the action tab ([click here to see past actions](https://github.com/McGill-NLP/instruct-qa/actions/workflows/publish-python.yml)).

You don't need to do anything else.

For versioning, we use https://semver.org/